### PR TITLE
Method stubbing before spring context initialization

### DIFF
--- a/springockito-annotations/src/main/java/org/kubek2k/springockito/annotations/Stub.java
+++ b/springockito-annotations/src/main/java/org/kubek2k/springockito/annotations/Stub.java
@@ -1,0 +1,12 @@
+package org.kubek2k.springockito.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface Stub {
+	String value();
+}

--- a/springockito-annotations/src/main/java/org/kubek2k/springockito/annotations/internal/MockitoMockSettings.java
+++ b/springockito-annotations/src/main/java/org/kubek2k/springockito/annotations/internal/MockitoMockSettings.java
@@ -1,5 +1,7 @@
 package org.kubek2k.springockito.annotations.internal;
 
+import java.lang.reflect.Method;
+
 import org.mockito.Answers;
 import org.mockito.MockSettings;
 import org.mockito.internal.creation.MockSettingsImpl;
@@ -10,6 +12,7 @@ public class MockitoMockSettings {
     private Class<?>[] extraInterfaces;
     private String mockName;
     private Answers defaultAnswer;
+    private Method mockBehavior;
 
     public MockSettings getMockSettings() {
         return createMockSettings();
@@ -47,5 +50,14 @@ public class MockitoMockSettings {
     public MockitoMockSettings withDefaultAnswer(Answers defaultAnswer) {
         this.defaultAnswer = defaultAnswer;
         return this;
+    }
+
+    public MockitoMockSettings withMockBehavior(Method mockBehavior) {
+        this.mockBehavior = mockBehavior;
+        return this;
+    }
+
+    public Method getMockBehavior() {
+        return mockBehavior;
     }
 }

--- a/springockito-annotations/src/main/java/org/kubek2k/springockito/annotations/internal/definitions/MockDefinition.java
+++ b/springockito-annotations/src/main/java/org/kubek2k/springockito/annotations/internal/definitions/MockDefinition.java
@@ -1,6 +1,9 @@
 package org.kubek2k.springockito.annotations.internal.definitions;
 
 import org.kubek2k.springockito.annotations.internal.MockitoMockSettings;
+
+import java.lang.reflect.Method;
+
 import org.kubek2k.springockito.annotations.ReplaceWithMock;
 import org.kubek2k.springockito.annotations.internal.definer.MockDefiner;
 import org.kubek2k.springockito.annotations.internal.definitions.bean.SpringockitoBeanDefinition;
@@ -9,6 +12,7 @@ public class MockDefinition extends AbstractDefinition<MockDefinition>{
 
     private ReplaceWithMock annotationInstance;
     private Class<?> mockClass;
+    private Method mockBehavior;
 
     public Class<?> getMockClass() {
         return mockClass;
@@ -18,7 +22,8 @@ public class MockDefinition extends AbstractDefinition<MockDefinition>{
         return new MockitoMockSettings()
                 .withMockName(annotationInstance.name())
                 .withDefaultAnswer(annotationInstance.defaultAnswer())
-                .withExtraInterfaces(annotationInstance.extraInterfaces());
+                .withExtraInterfaces(annotationInstance.extraInterfaces())
+                .withMockBehavior(mockBehavior);
     }
 
     public MockDefinition withAnnotationInstance(ReplaceWithMock annotationInstance) {
@@ -28,6 +33,11 @@ public class MockDefinition extends AbstractDefinition<MockDefinition>{
 
     public MockDefinition withMockClass(Class<?> mockClass) {
         this.mockClass = mockClass;
+        return this;
+    }
+    
+    public MockDefinition withMockBehavior(Method mockBehavior) {
+        this.mockBehavior = mockBehavior;
         return this;
     }
 

--- a/springockito-annotations/src/main/java/org/kubek2k/springockito/core/internal/mock/MockFactorySpringockito.java
+++ b/springockito-annotations/src/main/java/org/kubek2k/springockito/core/internal/mock/MockFactorySpringockito.java
@@ -1,5 +1,7 @@
 package org.kubek2k.springockito.core.internal.mock;
 
+import java.lang.reflect.Method;
+
 import org.kubek2k.springockito.annotations.internal.MockitoMockSettings;
 import org.kubek2k.springockito.core.internal.ResettableSpringockito;
 import org.mockito.MockSettings;
@@ -24,6 +26,10 @@ public class MockFactorySpringockito<T> implements FactoryBean<T>, ResettableSpr
     public T getObject() throws Exception {
         if (instance == null) {
             instance = Mockito.mock(mockClass, getMockSettings());
+            Method method = mockitoMockSettings.getMockBehavior();
+            if (method != null) {
+                method.invoke(null, instance);
+            }
         }
         return instance;
     }

--- a/springockito-annotations/src/test/java/org/kubek2k/springockito/annotations/it/SpringockitoAnnotationsMocksIntegrationTest.java
+++ b/springockito-annotations/src/test/java/org/kubek2k/springockito/annotations/it/SpringockitoAnnotationsMocksIntegrationTest.java
@@ -1,7 +1,13 @@
 package org.kubek2k.springockito.annotations.it;
 
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
 import org.kubek2k.springockito.annotations.ReplaceWithMock;
 import org.kubek2k.springockito.annotations.SpringockitoContextLoader;
+import org.kubek2k.springockito.annotations.Stub;
 import org.kubek2k.springockito.annotations.it.beans.InnerBean;
 import org.kubek2k.springockito.annotations.it.beans.OuterBean;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -10,18 +16,22 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.testng.AbstractTestNGSpringContextTests;
 import org.testng.annotations.Test;
 
-import static org.mockito.Mockito.verify;
-
 @ContextConfiguration(loader = SpringockitoContextLoader.class,
         locations = "classpath:/mockContext.xml")
 public class SpringockitoAnnotationsMocksIntegrationTest extends AbstractTestNGSpringContextTests {
-
+    private static final int TEST_RETURN_VALUE = 1234;
+    
     @ReplaceWithMock
     @Autowired
     private InnerBean innerBean;
 
     @Autowired
     private OuterBean outerBean;
+    
+    @Stub("innerBean")
+    public static void mockBehavior(InnerBean mockedInnerBeanInstance) {
+        when(mockedInnerBeanInstance.doSomething()).thenReturn(TEST_RETURN_VALUE);
+    }
 
     @Test
     @DirtiesContext
@@ -31,4 +41,14 @@ public class SpringockitoAnnotationsMocksIntegrationTest extends AbstractTestNGS
         verify(innerBean).doSomething();
     }
 
+    @Test
+    @DirtiesContext
+    public void shouldDefineMockedBehaviorForMock() {
+        int value = innerBean.doSomething();
+
+        assertEquals(TEST_RETURN_VALUE, value);
+
+        verify(innerBean).doSomething();
+        verifyNoMoreInteractions(innerBean);
+    }
 }


### PR DESCRIPTION
I have a test case where I need to stub some methods before the spring initialization is completed, as soon as the mock is created (for example because the mock is injected into other beans that calls some method during the initialization).
Unfortunately the methods annotated with Before are executed only when the spring initialization is complete.
A possible solution is a new annotation to mark a method that need to be called as soon as a mock is created.
Example:
```
public class TestCase {
    @ReplaceWithMock
    @Autowired @Qualifier("myMock")
    MyInterface mock1;

    @Stub("myMock")
    public static void stubMyMock(MyInterface mock) {
        when(mock.method()).thenReturn(...);
        ...
    }

```
In this case the method "stubMyMock" need to be executed as soon as the mock is created.